### PR TITLE
Alterado o modo de seleção da data de abertura de um balanço mensal

### DIFF
--- a/module/FinancialManagement/src/FinancialManagement/Form/Fieldset/OpenMonthBalanceFieldset.php
+++ b/module/FinancialManagement/src/FinancialManagement/Form/Fieldset/OpenMonthBalanceFieldset.php
@@ -68,8 +68,8 @@ class OpenMonthBalanceFieldset extends Fieldset implements InputFilterProviderIn
                     array(
                         'name' => 'Recruitment\Filter\DateToFormat',
                         'options' => array(
-                            'inputFormat' => 'm/Y',
-                            'outputFormat' => 'Y-m'
+                            'inputFormat' => 'd/m/Y',
+                            'outputFormat' => 'Y-m-d'
                         ),
                     ),
                 ),
@@ -77,7 +77,7 @@ class OpenMonthBalanceFieldset extends Fieldset implements InputFilterProviderIn
                     array(
                         'name' => 'Zend\Validator\Date',
                         'options' => array(
-                            'format' => 'Y-m',
+                            'format' => 'Y-m-d',
                         ),
                     ),
                 ),

--- a/module/FinancialManagement/view/financial-management/cash-flow/month-balances.phtml
+++ b/module/FinancialManagement/view/financial-management/cash-flow/month-balances.phtml
@@ -19,7 +19,7 @@
                         <?php foreach ($this->monthBalances as $monthBalance): ?>
                             <tr class="cats-row" data-id="<?php echo $monthBalance->getMonthlyBalanceId(); ?>" id="month-balance-<?php echo $monthBalance->getMonthlyBalanceId(); ?>">
                                 <td class="text-center"> <?php echo $monthBalance->getMonthlyBalanceId(); ?></td>
-                                <td class="text-center"> <?php echo $monthBalance->getMonthlyBalanceOpen()->format("m/Y"); ?></td>
+                                <td class="text-center"> <?php echo $monthBalance->getMonthlyBalanceOpen()->format("d/m/Y"); ?></td>
                                 <td class="text-center"> 
                                     <?php
                                     echo ($monthBalance->getMonthlyBalanceClose() !== NULL) ?

--- a/public/js/app/pages/financial-management/cash-flow/open-month-balance.js
+++ b/public/js/app/pages/financial-management/cash-flow/open-month-balance.js
@@ -9,10 +9,10 @@ define(['jquery', 'datetimepicker'], function () {
 
         initDatepicker = function () {
             $('.datepicker').closest('.input-group').datetimepicker({
-                format: 'MM/YYYY',
+                format: 'DD/MM/YYYY',
                 useCurrent: false,
                 locale: 'pt-br',
-                viewMode: 'months'
+                viewMode: 'days'
             });
         };
 


### PR DESCRIPTION
Antes escolhia-se o mês e, por padrão, o dia selecionado era um. Agora é possível selecionar um dia de abertura.