### PR TITLE
Corrigida configuração dos Validators StringToUpper e StringToLower

### DIFF
--- a/module/AdministrativeStructure/src/AdministrativeStructure/Form/Fieldset/JobFieldset.php
+++ b/module/AdministrativeStructure/src/AdministrativeStructure/Form/Fieldset/JobFieldset.php
@@ -109,7 +109,12 @@ class JobFieldset extends Fieldset implements InputFilterProviderInterface
             'jobName' => [
                 'required' => true,
                 'filters' => [
-                    ['name' => 'StringToUpper'],
+                    [
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ],
                 ],
                 'validators' => [
                     [

--- a/module/FinancialManagement/src/FinancialManagement/Form/Fieldset/CashFlowTypeFieldset.php
+++ b/module/FinancialManagement/src/FinancialManagement/Form/Fieldset/CashFlowTypeFieldset.php
@@ -74,7 +74,12 @@ class CashFlowTypeFieldset extends Fieldset implements InputFilterProviderInterf
                 'filters' => array(
                     array('name' => 'StripTags'),
                     array('name' => 'StringTrim'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(

--- a/module/Recruitment/src/Recruitment/Form/Fieldset/AddressFieldset.php
+++ b/module/Recruitment/src/Recruitment/Form/Fieldset/AddressFieldset.php
@@ -150,7 +150,12 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
                 'name' => 'city',
                 'required' => true,
                 'filters' => array(
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(
@@ -166,7 +171,12 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
                 'name' => 'neighborhood',
                 'required' => true,
                 'filters' => array(
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ),
                 ),
                 'validators' => array(
                     array(
@@ -182,7 +192,12 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
                 'name' => 'street',
                 'required' => true,
                 'filters' => array(
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ),
                 ),
                 'validators' => array(
                     array(
@@ -211,7 +226,12 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
                 'name' => 'complement',
                 'required' => false,
                 'filters' => array(
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ),
                 ),
                 'validators' => array(
                     array(

--- a/module/Recruitment/src/Recruitment/Form/Fieldset/PersonFieldset.php
+++ b/module/Recruitment/src/Recruitment/Form/Fieldset/PersonFieldset.php
@@ -30,16 +30,16 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
      * @throws \InvalidArgumentException
      */
     public function __construct(ObjectManager $obj,
-        $options = array(
+            $options = array(
         'relative' => false,
         'address' => false,
         'social_media' => false,
     ), $name = 'person')
     {
         if (is_array($options) &&
-            (!array_key_exists('relative', $options) ||
-            !array_key_exists('address', $options) ||
-            !array_key_exists('social_media', $options))) {
+                (!array_key_exists('relative', $options) ||
+                !array_key_exists('address', $options) ||
+                !array_key_exists('social_media', $options))) {
             throw new \InvalidArgumentException('`options` array must contain the keys `relative`, `address`'
             . ' and `social_media`');
         }
@@ -47,7 +47,7 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
         parent::__construct($name);
 
         $this->setHydrator(new DoctrineHydrator($obj))
-            ->setObject(new Person());
+                ->setObject(new Person());
 
         if ($options['relative']) {
             $relativeFieldset = new RelativeFieldset($obj);
@@ -198,7 +198,12 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'filters' => array(
                     array('name' => 'StripTags'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(
@@ -214,7 +219,12 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'filters' => array(
                     array('name' => 'StripTags'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ),
                 ),
                 'validators' => array(
                     array(
@@ -264,7 +274,12 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'filters' => array(
                     array('name' => 'StringTrim'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ),
                 ),
                 'validadors' => array(
                     array(
@@ -294,7 +309,12 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
             'personEmail' => array(
                 'required' => true,
                 'filters' => [
-                    ['name' => 'StringToLower']
+                    [
+                        'name' => 'StringToLower',
+                        'options' => [
+                            'encoding' => 'UTF-8',
+                        ],
+                    ],
                 ],
                 'validators' => array(
                     array(

--- a/module/Recruitment/src/Recruitment/Form/Fieldset/PreInterviewFieldset.php
+++ b/module/Recruitment/src/Recruitment/Form/Fieldset/PreInterviewFieldset.php
@@ -264,7 +264,12 @@ class PreInterviewFieldset extends Fieldset implements InputFilterProviderInterf
             'preInterviewHighSchool' => array(
                 'required' => true,
                 'filters' => array(
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(

--- a/module/Recruitment/src/Recruitment/Form/Fieldset/RelativeFieldset.php
+++ b/module/Recruitment/src/Recruitment/Form/Fieldset/RelativeFieldset.php
@@ -55,7 +55,12 @@ class RelativeFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'filters' => array(
                     array('name' => 'StripTags'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(

--- a/module/SchoolManagement/src/SchoolManagement/Form/Fieldset/SubjectFieldset.php
+++ b/module/SchoolManagement/src/SchoolManagement/Form/Fieldset/SubjectFieldset.php
@@ -85,7 +85,12 @@ class SubjectFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'filters' => array(
                     array('name' => 'StripTags'),
-                    array('name' => 'StringToUpper'),
+                    array(
+                        'name' => 'StringToUpper',
+                        'options' => array(
+                            'encoding' => 'UTF-8',
+                        ),
+                    ),
                 ),
                 'validators' => array(
                     array(

--- a/module/SchoolManagement/src/SchoolManagement/Form/StudentWarningFilter.php
+++ b/module/SchoolManagement/src/SchoolManagement/Form/StudentWarningFilter.php
@@ -26,7 +26,12 @@ class StudentWarningFilter extends InputFilter
                     'filters' => array(
                         array('name' => 'StringTrim'),
                         array('name' => 'StripTags'),
-                        array('name' => 'StringToUpper'),
+                        array(
+                            'name' => 'StringToUpper',
+                            'options' => array(
+                                'encoding' => 'UTF-8',
+                            ),
+                        ),
                     ),
                     'validators' => array(
                         array(

--- a/module/Site/src/Site/Form/ContactFilter.php
+++ b/module/Site/src/Site/Form/ContactFilter.php
@@ -26,7 +26,12 @@ class ContactFilter extends InputFilter
                     'filters' => array(
                         array('name' => 'StringTrim'),
                         array('name' => 'StripTags'),
-                        array('name' => 'StringToUpper'),
+                        array(
+                            'name' => 'StringToUpper',
+                            'options' => array(
+                                'encoding' => 'UTF-8',
+                            ),
+                        ),
                     ),
                     'validators' => array(
                         array(
@@ -60,7 +65,12 @@ class ContactFilter extends InputFilter
                     'filters' => array(
                         array('name' => 'StringTrim'),
                         array('name' => 'StripTags'),
-                        array('name' => 'StringToUpper'),
+                        array(
+                            'name' => 'StringToUpper',
+                            'options' => [
+                                'encoding' => 'UTF-8',
+                            ],
+                        ),
                     ),
                     'validators' => array(
                         array(
@@ -78,7 +88,12 @@ class ContactFilter extends InputFilter
                     'filters' => array(
                         array('name' => 'StringTrim'),
                         array('name' => 'StripTags'),
-                        array('name' => 'StringToUpper'),
+                        array(
+                            'name' => 'StringToUpper',
+                            'options' => [
+                                'encoding' => 'UTF-8',
+                            ],
+                        ),
                     ),
                     'validators' => array(
                         array(


### PR DESCRIPTION
Adicionado às opções dos Validators StringToUpper e StringToLower a codificação UTF-8, assim não ocorrerão erros ao tentar validar palavras com caracteres especiais, como acentos.

Antes: 
array(
----'name' => 'StringToUpper', // ou StringToLower
),

Agora: 
array(
----'name' => 'StringToUpper', // ou StringToLower
----'options' => array(
--------'encoding' => 'UTF-8',
----),
),