### PR TITLE
Correção do validator StringToLower do campo de email

### DIFF
--- a/module/Recruitment/src/Recruitment/Form/Fieldset/PersonFieldset.php
+++ b/module/Recruitment/src/Recruitment/Form/Fieldset/PersonFieldset.php
@@ -309,12 +309,7 @@ class PersonFieldset extends Fieldset implements InputFilterProviderInterface
             'personEmail' => array(
                 'required' => true,
                 'filters' => [
-                    [
-                        'name' => 'StringToLower',
-                        'options' => [
-                            'encoding' => 'UTF-8',
-                        ],
-                    ],
+                    ['name' => 'StringToLower'],
                 ],
                 'validators' => array(
                     array(


### PR DESCRIPTION
O campo de email não precisa ser validado utilizando a codificação UTF-8 portanto esta opção foi removida.