### PR TITLE
Correção Links Parceiros

### DIFF
--- a/module/Site/view/site/index/index.phtml
+++ b/module/Site/view/site/index/index.phtml
@@ -126,13 +126,13 @@
         <hr>
         <div class="row">
             <div class="col-lg-4 col-sm-6 text-center">
-                <a href="http://unifei.edu.br/"><img src="/img/unifei.png" alt="Unifei" width="200"></a>
+                <a href="http://www.unifei.edu.br/"><img src="/img/unifei.png" alt="Unifei" width="200"></a>
             </div>
             <div class="col-lg-4 col-sm-6 text-center">
                 <a href="http://www.speaking.com.br/"><img src="/img/speaking.png" alt="Speaking" width="200"></a>
             </div>
             <div class="col-lg-4 col-sm-12 text-center">
-                <a href="http://unifei.edu.br/"><img src="/img/casdvest.png" alt="CASD" width="200"></a>
+                <a href="http://www.casdvest.org.br/"><img src="/img/casdvest.png" alt="CASD" width="200"></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Substituição de "unifei.edu.br" para "www.unifei.edu.br". O site da UNIFEI não aceita o Google Chrome via link sem "www".
Atualização do link do CasD Vestibulares.