### PR TITLE
Correção do email de placeholder

### DIFF
--- a/data/dev-helpers/ubuntu-16.04-setup-environment.sh
+++ b/data/dev-helpers/ubuntu-16.04-setup-environment.sh
@@ -99,13 +99,13 @@ return [
        ],
    ],
    'email_config' => [
-      'from_recruitment' => '<colocar um email>',
+      'from_recruitment' => 'email@hostname',
       'from_recruitment_name' => '<nome do remetente>',
       'smtp_options' => [
          'host' => 'smtp.gmail.com',
          'connection_class' => 'login',
          'config' => [
-            'username' => '<colocar um email>',
+            'username' => 'email@hostname',
             'password' => '<colocar a senha do email>',
             'ssl' => 'tls',
          ],


### PR DESCRIPTION
o email de placeholder também deve seguir um formato válido de email. Isso permite que as páginas que utilizam o serviço de envio de email possam ser acessadas no ambiente de desenvolvimento.