### PR TITLE
Corrigido erro da geração de provas 

### DIFF
--- a/module/SchoolManagement/view/school-management/school-exam/prepare-application.phtml
+++ b/module/SchoolManagement/view/school-management/school-exam/prepare-application.phtml
@@ -58,17 +58,17 @@
                         <ul>
                             <?php foreach ($this->application->getExams() as $exam) : ?>
                                 <li>
-                                    <span id="exam-name-input"><?php echo $exam->getName() ?></span>
+                                    <span id="content-<?php echo $exam->getContent()->getExamContentId()?>-name"><?php echo $exam->getName() ?></span>
                                 </li>
                                     <?php echo 'Dia: '; ?>
-                                    <span id="exam-day">
+                                    <span id="content-<?php echo $exam->getContent()->getExamContentId()?>-day">
                                         <?php echo $exam->getDate()->format('d/m/Y'); ?>    
                                     </span><br>
                                     <?php echo 'Hora: '; ?>
-                                    <span id="exam-start-time">
+                                    <span id="content-<?php echo $exam->getContent()->getExamContentId()?>-start-time">
                                         <?php echo $exam->getStartTime()->format('H:i'); ?>    
                                     </span> - 
-                                    <span id="exam-end-time">
+                                    <span id="content-<?php echo $exam->getContent()->getExamContentId()?>-end-time">
                                         <?php echo $exam->getEndTime()->format('H:i'); ?>    
                                     </span><br> 
                             <?php endforeach; ?>

--- a/public/js/app/pages/school-management/exam/prepare-application.js
+++ b/public/js/app/pages/school-management/exam/prepare-application.js
@@ -57,15 +57,16 @@ define(['jquery', 'mathjax', 'jquerycolumnizer', 'jqueryprint'], function () {
              */
             $('.print-exam').click(function () {
                 var pageNumber = 1;
-
+                var contentId = $(this).closest('.application-content').data('content-id');
+                
                 var instructionsPage = '';
                 var wordingPage = '';
                 
                 if ($(this).closest('.exam').find('.exam-instructions').is(":checked")) {
-                    var examName = $('#exam-name-input').text().trim() || "PROVA";
-                    var examDate = $('#exam-day').text().trim();
-                    var examBeginTime = $('#exam-start-time').text().trim();
-                    var examEndTime = $('#exam-end-time').text().trim();
+                    var examName = $('#content-' + contentId + '-name').text().trim() || "PROVA";
+                    var examDate = $('#content-' + contentId + '-day').text().trim();
+                    var examBeginTime = $('#content-' + contentId + '-start-time').text().trim();
+                    var examEndTime = $('#content-' + contentId + '-end-time').text().trim();
 
                     /*
                      * TODO: Usar template disponível na página


### PR DESCRIPTION
O erro fazia com que o nome, a data e o horário da prova não fossem mostrados na página de instruções, quando ela era inserida.