### PR TITLE
Adiciona compatibilidade com Formscanner v1.1.3.

### DIFF
--- a/public/js/app/pages/school-management/exam/UploadAnswers.js
+++ b/public/js/app/pages/school-management/exam/UploadAnswers.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2016 Márcio Dias <marciojr91@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -89,7 +89,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         addDataToTable = function () {
@@ -117,7 +117,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         readAnswers = function () {
@@ -163,26 +163,26 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
                 ans = loadedAnswers[loadedCsvData[i][0]].answers;
                 questionCounter = chosenExam.content.questionsStartAtNumber;
-                
+
                 loadedSubjects.forEach(function (subject) {
                     group = mapToFileGroup[subject.name];
                     objFg = fileGroups[group];
-                    
+
                     var ansArr = loadedCsvData[i].slice(objFg.startAt, objFg.startAt + objFg.amount);
-                    
+
                     for(var q = 0; q < ansArr.length; q++, questionCounter++) {
                         ans[questionCounter] = ansArr[q];
                     }
                 });
             }
-            
+
             console.log('loadedAnswers', loadedAnswers);
-            
+
         };
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         adjustGroups = function () {
@@ -203,7 +203,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         drawGroups = function () {
@@ -261,7 +261,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         mountGroups = function () {
@@ -272,7 +272,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
             var lastLabel = null;
             header.forEach(function (item, index) {
                 if (index > 0) {
-                    var label = item.split(']', 1)[0].substr(1);
+                    var label = item.split('.')[0];
                     if (label !== lastLabel) {
                         fileGroups[label] = {startAt: index, amount: 0};
                         lastLabel = label;
@@ -284,7 +284,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         getExams = function () {
@@ -306,7 +306,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         fetchData = function () {
@@ -353,7 +353,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         readSubjects = function () {
@@ -390,7 +390,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         createStudentTable = function () {
@@ -417,7 +417,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @param {type} $tr
          * @returns {undefined}
          */
@@ -456,7 +456,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
                         } else {
                             len = 0;
                         }
-                        
+
                         console.log('len', len);
 
                         for (var i = 0; i < len; i++) {
@@ -478,7 +478,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
         };
 
         /**
-         * 
+         *
          */
         getPrevAnswers = function (registration, examId) {
             return $.ajax({
@@ -493,7 +493,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @returns {undefined}
          */
         createCandidateTable = function () {
@@ -516,7 +516,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @param {type} classId
          * @returns {jqXHR} promise
          */
@@ -532,7 +532,7 @@ define(['bootbox', 'jquerycsv'], function (bootbox) {
 
         /**
          * Done
-         * 
+         *
          * @param {type} recId
          * @returns {jqXHR}
          */

--- a/public/js/app/pages/school-management/exam/preview.js
+++ b/public/js/app/pages/school-management/exam/preview.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2016 Márcio Dias <marciojr91@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -44,7 +44,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
      *      },
      * ...
      * }
-     * 
+     *
      * @type object
      */
     var studentAnswers = null;
@@ -54,29 +54,29 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
      * finalTemplate = {
      *      groups: ["Group 1", "Group 2", ...],
      *      answers: [
-     *          {group: "Group 1", answer: "A"}, 
-     *          {group: "Group 1", answer: "D"}, 
-     *          ..., 
-     *          {group: "Group 2", answer: "C"}, 
+     *          {group: "Group 1", answer: "A"},
+     *          {group: "Group 1", answer: "D"},
+     *          ...,
+     *          {group: "Group 2", answer: "C"},
      *          ...
      *      ]
      * }
-     * 
+     *
      * Exemplo
      * finalTemplate = {
      *      groups: [
-     *          "Linguagens Códigos e Suas Tecnologias", 
+     *          "Linguagens Códigos e Suas Tecnologias",
      *          "Ciências da Natureza e Suas Tecnologias"
      *      ],
      *      answers: [
-     *          {group: "Linguagens Códigos e Suas Tecnologias", answer: "A"}, 
-     *          {group: "Linguagens Códigos e Suas Tecnologias", answer: "D"}, 
+     *          {group: "Linguagens Códigos e Suas Tecnologias", answer: "A"},
+     *          {group: "Linguagens Códigos e Suas Tecnologias", answer: "D"},
      *          ...,
-     *          {group: "Ciências da Natureza e Suas Tecnologias", answer: "C"}, 
+     *          {group: "Ciências da Natureza e Suas Tecnologias", answer: "C"},
      *          ...
      *      ]
      * }
-     * 
+     *
      * @type object
      */
     var finalTemplate = {
@@ -270,7 +270,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
 
     /**
      * Gabarito
-     * 
+     *
      * @returns {undefined}
      */
     createTemplateTable = function () {
@@ -302,7 +302,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
     };
     /**
      * Cria o vetor de respostas combinando com os nomes dos alunos
-     * 
+     *
      * @returns {undefined}
      */
     processStudents = function () {
@@ -331,7 +331,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
     };
     /**
      * Organiza o gabarito.
-     * 
+     *
      * @returns {undefined}
      */
     processTemplate = function () {
@@ -341,7 +341,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
         finalTemplate.answers = [];
         var group = null;
         for (var i = 1; i < csvData.template[1].length; i++) {
-            group = csvData.template[0][i].split("]")[0].substring(1);
+            group = csvData.template[0][i].split(".")[0];
             if (lastGroup !== group) {
                 lastGroup = group;
                 finalTemplate.groups.push(group);
@@ -356,7 +356,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
     };
     /**
      * Lê os arquivos csv
-     * 
+     *
      * @returns {undefined}
      */
     bindImportEvent = function () {
@@ -384,7 +384,7 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
 
 
     /**
-     * 
+     *
      * @param {type} classId
      * @returns {jqXHR} promise
      */
@@ -413,6 +413,6 @@ define(['bootbox', 'datatable', 'jquerycsv'], function (bootbox) {
             }
         };
     }());
-    
+
     return preview;
 });


### PR DESCRIPTION
O formscanner alterou o formato dos titulos das colunas de questões de **[group] [question]** para **group.question** no arquivo csv. Este *pull request* ajusta o script (das páginas de cálculo de acertos e de upload de respostas de processos seletivos de alunos) para que o csv seja importado corretamente.

Exemplo:
Formscanner < v1.1.3

| filename | [Matemática]Question001 | [Matemática]Question002 | ... |
| --- | --- | --- | --- |
| img-01 | A | B | --- |
| img-02 | A | C | --- |

Formscanner >= v1.1.3

| filename | Matemática.Question001 | Matemática.Question002 | ... |
| --- | --- | --- | --- |
| img-01 | A | B | --- |
| img-02 | A | C | --- |


Para mais informações: [CHANGELOG do Formscanner](https://sourceforge.net/p/formscanner/wiki/CHANGELOG/).